### PR TITLE
Remove -legacy compiler flag dependency; expose profiling attributes

### DIFF
--- a/CharType.ecl
+++ b/CharType.ecl
@@ -1,4 +1,5 @@
-EXPORT CharType := #IF (UnicodeCfg.UseUnicode)
+IMPORT SALT_Profile;
+EXPORT CharType := #IF (SALT_Profile.UnicodeCfg.UseUnicode)
   UNICODE1
 #ELSE
   STRING1

--- a/Fn_Data_Pattern.ecl
+++ b/Fn_Data_Pattern.ecl
@@ -1,4 +1,7 @@
-EXPORT Fn_Data_Pattern(StrType s) := #IF (UnicodeCfg.UseUnicode)
+IMPORT SALT_Profile;
+IMPORT lib_stringlib;
+
+EXPORT Fn_Data_Pattern(SALT_Profile.StrType s) := #IF (SALT_Profile.UnicodeCfg.UseUnicode)
   unicodelib.unicodesubstituteout(
     unicodelib.unicodesubstituteout(
       unicodelib.unicodesubstituteout(s,U'ABCDEFGHIJKLMNOPQRSTUVWXYZ',U'A'),

--- a/MAC_Character_Counts.ecl
+++ b/MAC_Character_Counts.ecl
@@ -1,3 +1,4 @@
+IMPORT SALT_Profile;
 EXPORT MAC_Character_Counts := MODULE
   SHARED MaxExamples := 300;
   SHARED MaxChars := 256; // Change to allow more than 256 different characters in string
@@ -76,7 +77,7 @@ EXPORT MAC_Character_Counts := MODULE
     Len2Size(UNSIGNED2 c) := MAP ( c < 3 => 1, c < 5 => 2, c < 7 => 3, c < 9 => 4, c < 11 => 5, c < 14 => 6, c < 16 => 7, 8 );
     boiler := DATASET([{0,RName+' := RECORD'},{100000,'  END;'}],r1);
     r1 WriteEcl(t le) := TRANSFORM
-      #IF (UnicodeCfg.UseUnicode)
+      #IF (SALT_Profile.UnicodeCfg.UseUnicode)
         SELF.Txt := '  '+MAP( ~le.AllNum => 'UNICODE' + IF(le.MaxLen<MaxFixedLen,(SALT_Profile.StrType)le.MaxLen, ''),
       #ELSE
         SELF.Txt := '  '+MAP( ~le.AllNum => 'STRING' + IF(le.MaxLen<MaxFixedLen,(SALT_Profile.StrType)le.MaxLen, ''),

--- a/MAC_Correlate.ecl
+++ b/MAC_Correlate.ecl
@@ -1,3 +1,4 @@
+IMPORT SALT_Profile;
 EXPORT MAC_Correlate := MODULE
   SHARED MaxExamples := 300;
   SHARED MaxRel := 100;
@@ -9,7 +10,7 @@ EXPORT MAC_Correlate := MODULE
     UNSIGNED2 FldNo2;
   END;
 	
-  SHARED Field_Identification := MAC_Character_Counts.Field_Identification;
+  SHARED Field_Identification := SALT_Profile.MAC_Character_Counts.Field_Identification;
   SHARED Cor := RECORD
     UNSIGNED2 FldNo;
     SALT_Profile.StrType FieldName;

--- a/MAC_Profile.ecl
+++ b/MAC_Profile.ecl
@@ -14,5 +14,19 @@
  *   SALT_Profile.MAC_Profile(my_dataset,maxFieldCorr:=75);
  */
 EXPORT MAC_Profile(inFile,id_field='',src_field='',CorrelateSampleSize=100000000,out_prefix='',maxFieldCorr=50) := MACRO
-  SALT_Profile.MOD_Profile(inFile,id_field,src_field,CorrelateSampleSize,out_prefix,maxFieldCorr).out;
+  profile_mod := SALT_Profile.MOD_Profile(inFile,id_field,src_field,CorrelateSampleSize,out_prefix,maxFieldCorr);
+  // Execute the output actions
+  profile_mod.out;
+
+  /*
+  Several exported attributes are also available, corresponding with the workunit results created by profile_mod.out:
+
+  profile_mod.Summary
+  profile_mod.invSummary
+  profile_mod.AllProfiles
+  profile_mod.optLayout
+  profile_mod.Types
+
+  You can reference the above attributes in your calling code after you have called MAC_Profile().
+  */
 ENDMACRO;

--- a/Str30Type.ecl
+++ b/Str30Type.ecl
@@ -1,4 +1,5 @@
-EXPORT Str30Type := #IF (UnicodeCfg.UseUnicode)
+IMPORT SALT_Profile;
+EXPORT Str30Type := #IF (SALT_Profile.UnicodeCfg.UseUnicode)
   UNICODE30
 #ELSE
   STRING30

--- a/StrType.ecl
+++ b/StrType.ecl
@@ -1,4 +1,5 @@
-EXPORT StrType := #IF(UnicodeCfg.UseUnicode)
+IMPORT SALT_Profile;
+EXPORT StrType := #IF(SALT_Profile.UnicodeCfg.UseUnicode)
   UNICODE
 #ELSE
   STRING

--- a/WordCount.ecl
+++ b/WordCount.ecl
@@ -6,8 +6,9 @@
  * @param sep     The string used to separate words
  */
 IMPORT STD;
-EXPORT UNSIGNED4 WordCount(StrType s, STRING1 sep=' ') := 
-#IF (UnicodeCfg.UseUnicode)
+IMPORT SALT_Profile;
+EXPORT UNSIGNED4 WordCount(SALT_Profile.StrType s, STRING1 sep=' ') := 
+#IF (SALT_Profile.UnicodeCfg.UseUnicode)
 			unicodelib.UnicodeLocaleWordCount(s, UnicodeCfg.LocaleName);
 #ELSE
 			STD.Str.CountWords( s, sep);


### PR DESCRIPTION
Also allow exported profiling attributes to be used in calling code

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>